### PR TITLE
Bugfix: wrong search order preventing import every new recommendation 

### DIFF
--- a/src/Resources/contao/classes/GooglePlacesApi.php
+++ b/src/Resources/contao/classes/GooglePlacesApi.php
@@ -55,8 +55,7 @@ class GooglePlacesApi extends Frontend
 
 		foreach($objRecommendationArchives as $objRecommendationArchive)
         {
-            $strSyncUrl = 'https://maps.googleapis.com/maps/api/place/details/json?language=' . ($objRecommendationArchive->syncLanguage ?? '') . '&place_id='.$objRecommendationArchive->googlePlaceId . '&fields=reviews&key=' . $objRecommendationArchive->googleApiToken;
-
+            $strSyncUrl = 'https://maps.googleapis.com/maps/api/place/details/json?reviews_sort=newest&language=' . ($objRecommendationArchive->syncLanguage ?? '') . '&place_id='.$objRecommendationArchive->googlePlaceId . '&fields=reviews&key=' . $objRecommendationArchive->googleApiToken;
 			$client = HttpClient::create();
 	        $arrContent = $client->request('POST', $strSyncUrl)->toArray();
 	        $objContent = (object) $arrContent;


### PR DESCRIPTION
By default, the Google Places API outputs the 5 most "interesting" reviews.  This prevents that all new reviews are actually imported. 

Fix: explicitly set reviews_sort to "newest" in the API call.

Parameter description: [API description](https://developers.google.com/maps/documentation/places/web-service/details?hl=de#reviews_sort)