### PR TITLE
Allow reviews to not be translated

### DIFF
--- a/src/Resources/contao/classes/GooglePlacesApi.php
+++ b/src/Resources/contao/classes/GooglePlacesApi.php
@@ -54,7 +54,20 @@ class GooglePlacesApi extends Frontend
 
         foreach ($objRecommendationArchives as $objRecommendationArchive)
         {
-            $strSyncUrl = 'https://maps.googleapis.com/maps/api/place/details/json?reviews_sort=newest&language=' . ($objRecommendationArchive->syncLanguage ?? '') . '&place_id=' . $objRecommendationArchive->googlePlaceId . '&fields=reviews&key=' . $objRecommendationArchive->googleApiToken;
+            $arrParams = [
+                'reviews_sort' => 'newest',
+                'place_id' => $objRecommendationArchive->googlePlaceId,
+                'fields' => 'reviews',
+                'key' => $objRecommendationArchive->googleApiToken,
+            ];
+
+            if ($objRecommendationArchive->syncLanguage) {
+                $arrParams['language'] = $objRecommendationArchive->syncLanguage;
+            } else {
+                $arrParams['reviews_no_translations'] = 'true';
+            }
+
+            $strSyncUrl = 'https://maps.googleapis.com/maps/api/place/details/json?' . http_build_query($arrParams);
             $client     = HttpClient::create();
             $arrContent = $client->request('POST', $strSyncUrl)->toArray();
             $objContent = (object)$arrContent;


### PR DESCRIPTION
When choosing no language for the translation for a recommendation archive I expected the reviews to not be translated at all. However, by default Google always translates the reviews and if no language is given, it will guess from the HTTP request headers - or just fallback to English. If you don't want the reviews to be translated, the `reviews_no_translations=true` parameter can be used for the API request.

This PR changes this behaviour so that if you do not define a translation language, the reviews will not actually be translated.